### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "RaspberryPi"
   ],
   "dependencies": {
-    "onoff": "^3.2.2",
-    "spi-device": "^2.0.6"
+    "onoff": "^6.0.3",
+    "spi-device": "^3.1.2"
   },
   "devDependencies": {
     "eslint": "^5.11.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "RaspberryPi"
   ],
   "dependencies": {
-    "onoff": "^6.0.3",
+    "onoff": "^6.0.4",
     "spi-device": "^3.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "RaspberryPi"
   ],
   "dependencies": {
-    "onoff": "^6.0.4",
+    "onoff": "^6.0.3",
     "spi-device": "^3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Original version doesn‘t install with current spi-device version. Updated onoff and spi-device version in package.json and now everythig works again, even in 64 bit environment. Cheers, Martin